### PR TITLE
Resolves #7

### DIFF
--- a/mayan/settings/base.py
+++ b/mayan/settings/base.py
@@ -252,7 +252,7 @@ STATICFILES_FINDERS = (
     'mayan.apps.views.finders.MayanAppDirectoriesFinder'
 )
 
-STATICFILES_STORAGE = 'whitenoise.storage.StaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 TEST_RUNNER = 'mayan.apps.testing.runner.MayanTestRunner'
 


### PR DESCRIPTION
Adding compression support in the WhiteNoise middleware in Django by changing the `STATICFILES_STORAGE` setting to `whitenoise.storage.CompressedManifestStaticFilesStorage`, which uses gzip or Brotli formats depending on the `Accept-Encoding` header.

The Performance section of Lighthouse score increased from 68 to 75, with the text compression warning now resolved.

