### PR TITLE
modified the invalid value of "aria-controls"

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -23,7 +23,7 @@
                             <div class="panel panel-default">
                                 <div class="panel-heading" role="tab" id="headingOne">
                                     <h4 class="panel-title">
-                                        <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
+                                        <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="navbar">
                                             <div class="pull-left">
                                                 {% if link.icon %}
                                                 <i class="hidden-xs hidden-sm hidden-md {{ link.icon }}"></i>


### PR DESCRIPTION
Resolves #6. The previous value of "aria-controls" is "collapseOne" which is recognized as invalid by Lighthouse when compared against the WAI-ARIA specification. It's now changed to "navbar", which improves the accessibility score from 85 to 91.