### PR TITLE
changed colors of a and btn-default to better match their backing colors

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -15,6 +15,10 @@ body {
     padding-top: 60px;
 }
 
+a {
+  color: #0b5a4b;
+}
+
 .navbar-brand {
     font-family: "IM Fell English SC", serif;
 }
@@ -404,6 +408,10 @@ a i {
 .btn-warning.btn-outline:hover,
 .btn-danger.btn-outline:hover {
     color: #fff;
+}
+
+.btn-default {
+  color: #161616
 }
 
 .btn-list > .btn {


### PR DESCRIPTION
The problematic color contrasts were 
a) between the light green of the links and the light gray of their background, which I fixed by changing that light green to dark green, and
b) between the white word "Search" and the light gray background of the button, which I fixed by changing that white to black.