### PR TITLE
Replaced missing href in menu_main html template

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -8,7 +8,7 @@
     <div class="panel-group" id="accordion-sidebar" role="tablist" aria-multiselectable="true">
         <div class="panel-heading" role="tab" id="menu-main-button-close">
             <h4 class="panel-title">
-                <a class="disabled" href="">
+                <a class="disabled" href="#top">
                     <i class="fa fa-angle-double-left"></i>
                 </a>
             </h4>


### PR DESCRIPTION
Resolves [#5](https://github.com/CMU-313/Mayan-EDMS/issues/5).

The previous link within the panel-title header was missing, meaning it was uncrawlable, even though the tag was disabled. It is now a reference to the top of the page, which is resolvable and crawlable.

Improves Lighthouse SEO score from 78 to 89.

