### PR TITLE
Use unique ARIA IDs for tab panel

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -21,7 +21,7 @@
                     {% with ' ' as link_classes %}
                         {% if link|common_get_type == "<class 'mayan.apps.navigation.classes.Menu'>" %}
                             <div class="panel panel-default">
-                                    <div class="panel-heading" role="tab" id="heading-{{ forloop.counter }}">
+                                <div class="panel-heading" role="tab" id="heading-{{ forloop.counter }}">
                                     <h4 class="panel-title">
                                         <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
                                             <div class="pull-left">

--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -21,7 +21,7 @@
                     {% with ' ' as link_classes %}
                         {% if link|common_get_type == "<class 'mayan.apps.navigation.classes.Menu'>" %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                    <div class="panel-heading" role="tab" id="heading-{{ forloop.counter }}">
                                     <h4 class="panel-title">
                                         <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
                                             <div class="pull-left">
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-{{ forloop.counter }}">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}
@@ -59,7 +59,7 @@
                             </div>
                         {% else %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="heading">
                                     <h4 class="panel-title">
                                         {% include 'navigation/generic_link_instance.html' %}
                                     </h4>


### PR DESCRIPTION
Fixes #3.

In the tab panel, multiple elements were using the same ARIA ID. This occurs because when elements of the panel get generated, they reuse the same statically-defined ID. To fix this, replace the ID used with a dynamically generated one. In this case, use the forloop counter to get a unique number for each element in the panel, which also reflects the naming behavior of some other elements in the side panel. After this change, the Accessibility score reported in Lighthouse increased from 89 to 96.