### PR TITLE
Increased accessibility of the 'Create cabinet' page by changing the …

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -113,7 +113,7 @@
                 {% else %}
                     {% render_field field class+="form-control" %}
                 {% endif %}
-                {% if field.help_text and not form_hide_help_text %}<p class="help-block">{{ field.help_text|safe }}</p>{% endif %}
+                {% if field.help_text and not form_hide_help_text %}<p>{{ field.help_text|safe }}</p>{% endif %}
             </div>
         {% endfor %}
 {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -83,13 +83,13 @@
                         {% if submit_label %}{{ submit_label }}{% else %}{% if form.instance %}{% trans 'Save' %}{% else %}{% trans 'Submit' %}{% endif %}{% endif %}
                     </button>
                     {% if previous %}
-                          &nbsp;<a class="btn btn-default" onclick='history.back();'>
-                            <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{% else %}{% trans 'Cancel' %}{% endif %}
-                          </a>
+                          &nbsp;<a class="btn btn-info" onclick='history.back();'>
+                            <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{
+                     % else %}{% trans 'Cancel' %}{% endif %}     </a>
                     {% endif %}
 
                     {% for button in extra_buttons %}
-                        <button class="btn btn-default" name="{% if form.prefix %}{{ form.prefix }}-{{ button.name }}{% else %}{{ button.name }}{% endif %}" type="submit">
+                        <button class="btn btn-info" name="{% if form.prefix %}{{ form.prefix }}-{{ button.name }}{% else %}{{ button.name }}{% endif %}" type="submit">
                             {% if button.icon %}
                                 {{ button.icon.render }}
                             {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_multiform_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_multiform_subtemplate.html
@@ -59,7 +59,7 @@
                     <button class="btn btn-primary btn-hotkey-default" name="{% if form.prefix %}{{ form.prefix }}-submit{% else %}submit{% endif %}" type="submit"><i class="fa fa-check"></i> {% if submit_label %}{{ submit_label }}{% else %}{% if object %}{% trans 'Save' %}{% else %}{% trans 'Submit' %}{% endif %}{% endif %}</button>
                 {% endif %}
                 {% if previous %}
-                      &nbsp;<a class="btn btn-default" onclick='history.back();'>
+                      &nbsp;<a class="btn btn-info" onclick='history.back();'>
                         <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{% else %}{% trans 'Cancel' %}{% endif %}
                       </a>
                 {% endif %}

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -60,7 +60,7 @@
                     <div class="modal-body">
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Close' %}</button>
+                        <button type="button" class="btn btn-info" data-dismiss="modal">{% trans 'Close' %}</button>
                     </div>
                 </div>
             </div>

--- a/mayan/apps/dynamic_search/templates/dynamic_search/search_box.html
+++ b/mayan/apps/dynamic_search/templates/dynamic_search/search_box.html
@@ -42,7 +42,7 @@
                         {% endif %}
                         <span class="input-group-btn">
                             {% if setting_disable_simple_search == False %}
-                                <button class="btn btn-default" type="submit">{% trans 'Search' %}</button>
+                                <button class="btn btn-info" type="submit">{% trans 'Search' %}</button>
                                 {% endif %}
                             <a class="btn btn-primary" href="" id="btnSearchAdvanced">{% if setting_disable_simple_search == False %}{% trans 'Advanced' %}{% else %}{% trans 'Advanced search' %}{% endif %}</a>
                         </span>


### PR DESCRIPTION
Resolves #13 

In the "Create cabinets" page, there were issues with accessibility regarding the contrast of elements. In order to solve this issue, I had to change the text of the description to black and change the background color of the cancel button from light grey to light blue. Overall, this had a slight improvement to the Accessibility Lighthouse score as it went from 83 to 85.