### PR TITLE
Add meta description to root.html

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -10,6 +10,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
+        <meta name="description" content="Mayan EDMS: Your documents. No surprises. Find what you need with advanced search, tagging and categorization capabilities.">
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />


### PR DESCRIPTION
Resolves #19. Adds meta description of Mayan to root page, increasing SEO lighthouse score from 82 to 91