### PR TITLE
Changed the color of the button danger background to increase contras…

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -393,8 +393,8 @@ a i {
     color: #f0ad4e;
 }
 
-.btn-danger.btn-outline {
-    color: #d9534f;
+.btn-danger {
+    background-color: #730e0b;
 }
 
 .btn-default.btn-outline:hover,


### PR DESCRIPTION
…t with text color

Resolves #22 

The background color of btn-danger used for the Actions dropdown menu on the Documents > Trash can page was darkened to increase the contrast with the text color. This improves the Accessibility score from 82 to 84.