### PR TITLE
Eliminate render-blocking resources (bootstrap.min.css)

### DIFF
--- a/mayan/apps/appearance/templates/appearance/base_plain.html
+++ b/mayan/apps/appearance/templates/appearance/base_plain.html
@@ -20,7 +20,725 @@
         </title>
 
         <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <!-- <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" /> -->
+        <style>
+            html {
+                font-family: sans-serif;
+                -ms-text-size-adjust: 100%;
+                -webkit-text-size-adjust: 100%
+            }
+            
+            body {
+                margin: 0
+            }
+            
+            article,
+            aside,
+            details,
+            figcaption,
+            figure,
+            footer,
+            header,
+            hgroup,
+            main,
+            menu,
+            nav,
+            section,
+            summary {
+                display: block
+            }
+            
+            a {
+                background-color: transparent
+            }
+            
+            a:active,
+            a:hover {
+                outline: 0
+            }
+            
+            b,
+            strong {
+                font-weight: bold
+            }
+            
+            svg:not(:root) {
+                overflow: hidden
+            }
+            
+            hr {
+                box-sizing: content-box;
+                height: 0
+            }
+            
+            button,
+            input,
+            optgroup,
+            select,
+            textarea {
+                color: inherit;
+                font: inherit;
+                margin: 0
+            }
+            
+            button {
+                overflow: visible
+            }
+            
+            button,
+            select {
+                text-transform: none
+            }
+            
+            button,
+            html input[type="button"],
+            input[type="reset"],
+            input[type="submit"] {
+                -webkit-appearance: button;
+                cursor: pointer
+            }
+            
+            input {
+                line-height: normal
+            }
+            
+            table {
+                border-collapse: collapse;
+                border-spacing: 0
+            }
+            
+            * {
+                box-sizing: border-box
+            }
+            
+            *:before,
+            *:after {
+                box-sizing: border-box
+            }
+            
+            html {
+                font-size: 10px;
+                -webkit-tap-highlight-color: rgba(0, 0, 0, 0)
+            }
+            
+            body {
+                font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-size: 15px;
+                line-height: 1.42857143;
+                color: #2c3e50;
+                background-color: #ffffff
+            }
+            
+            input,
+            button,
+            select,
+            textarea {
+                font-family: inherit;
+                font-size: inherit;
+                line-height: inherit
+            }
+            
+            a {
+                color: #18bc9c;
+                text-decoration: none
+            }
+            
+            a:hover,
+            a:focus {
+                color: #18bc9c;
+                text-decoration: underline
+            }
+            
+            hr {
+                margin-top: 21px;
+                margin-bottom: 21px;
+                border: 0;
+                border-top: 1px solid #ecf0f1
+            }
+            
+            .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                border: 0
+            }
+            
+            [role="button"] {
+                cursor: pointer
+            }
+            
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6,
+            .h1,
+            .h2,
+            .h3,
+            .h4,
+            .h5,
+            .h6 {
+                font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-weight: 400;
+                line-height: 1.1;
+                color: inherit
+            }
+            
+            h1,
+            .h1,
+            h2,
+            .h2,
+            h3,
+            .h3 {
+                margin-top: 21px;
+                margin-bottom: 10.5px
+            }
+            
+            h4,
+            .h4,
+            h5,
+            .h5,
+            h6,
+            .h6 {
+                margin-top: 10.5px;
+                margin-bottom: 10.5px
+            }
+            
+            h3,
+            .h3 {
+                font-size: 26px
+            }
+            
+            h4,
+            .h4 {
+                font-size: 19px
+            }
+            
+            .text-right {
+                text-align: right
+            }
+            
+            .container-fluid {
+                padding-right: 15px;
+                padding-left: 15px;
+                margin-right: auto;
+                margin-left: auto
+            }
+            
+            .row {
+                margin-right: -15px;
+                margin-left: -15px
+            }
+            
+            .col-xs-1,
+            .col-sm-1,
+            .col-md-1,
+            .col-lg-1,
+            .col-xs-2,
+            .col-sm-2,
+            .col-md-2,
+            .col-lg-2,
+            .col-xs-3,
+            .col-sm-3,
+            .col-md-3,
+            .col-lg-3,
+            .col-xs-4,
+            .col-sm-4,
+            .col-md-4,
+            .col-lg-4,
+            .col-xs-5,
+            .col-sm-5,
+            .col-md-5,
+            .col-lg-5,
+            .col-xs-6,
+            .col-sm-6,
+            .col-md-6,
+            .col-lg-6,
+            .col-xs-7,
+            .col-sm-7,
+            .col-md-7,
+            .col-lg-7,
+            .col-xs-8,
+            .col-sm-8,
+            .col-md-8,
+            .col-lg-8,
+            .col-xs-9,
+            .col-sm-9,
+            .col-md-9,
+            .col-lg-9,
+            .col-xs-10,
+            .col-sm-10,
+            .col-md-10,
+            .col-lg-10,
+            .col-xs-11,
+            .col-sm-11,
+            .col-md-11,
+            .col-lg-11,
+            .col-xs-12,
+            .col-sm-12,
+            .col-md-12,
+            .col-lg-12 {
+                position: relative;
+                min-height: 1px;
+                padding-right: 15px;
+                padding-left: 15px
+            }
+            
+            .col-xs-1,
+            .col-xs-2,
+            .col-xs-3,
+            .col-xs-4,
+            .col-xs-5,
+            .col-xs-6,
+            .col-xs-7,
+            .col-xs-8,
+            .col-xs-9,
+            .col-xs-10,
+            .col-xs-11,
+            .col-xs-12 {
+                float: left
+            }
+            
+            .col-xs-12 {
+                width: 100%
+            }
+            
+            .col-xs-10 {
+                width: 83.33333333%
+            }
+            
+            .col-xs-2 {
+                width: 16.66666667%
+            }
+            
+            .form-control {
+                display: block;
+                width: 100%;
+                height: 45px;
+                padding: 10px 15px;
+                font-size: 15px;
+                line-height: 1.42857143;
+                color: #2c3e50;
+                background-color: #ffffff;
+                background-image: none;
+                border: 1px solid #dce4ec;
+                border-radius: 4px;
+                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+                transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s
+            }
+            
+            .form-control::-webkit-input-placeholder {
+                color: #acb6c0
+            }
+            
+            .btn {
+                display: inline-block;
+                margin-bottom: 0;
+                font-weight: normal;
+                text-align: center;
+                white-space: nowrap;
+                vertical-align: middle;
+                -ms-touch-action: manipulation;
+                touch-action: manipulation;
+                cursor: pointer;
+                background-image: none;
+                border: 1px solid transparent;
+                padding: 10px 15px;
+                font-size: 15px;
+                line-height: 1.42857143;
+                border-radius: 4px;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none
+            }
+            
+            .btn-default {
+                color: #ffffff;
+                background-color: #95a5a6;
+                border-color: #95a5a6
+            }
+            
+            .btn-primary {
+                color: #ffffff;
+                background-color: #2c3e50;
+                border-color: #2c3e50
+            }
+            
+            .fade {
+                opacity: 0;
+                transition: opacity 0.15s linear
+            }
+            
+            .collapse {
+                display: none
+            }
+            
+            .caret {
+                display: inline-block;
+                width: 0;
+                height: 0;
+                margin-left: 2px;
+                vertical-align: middle;
+                border-top: 4px dashed;
+                border-top: 4px solid \9;
+                border-right: 4px solid transparent;
+                border-left: 4px solid transparent
+            }
+            
+            .input-group {
+                position: relative;
+                display: table;
+                border-collapse: separate
+            }
+            
+            .input-group .form-control {
+                position: relative;
+                z-index: 2;
+                float: left;
+                width: 100%;
+                margin-bottom: 0
+            }
+            
+            .input-group-addon,
+            .input-group-btn,
+            .input-group .form-control {
+                display: table-cell
+            }
+            
+            .input-group-addon,
+            .input-group-btn {
+                width: 1%;
+                white-space: nowrap;
+                vertical-align: middle
+            }
+            
+            .input-group .form-control:first-child,
+            .input-group-addon:first-child,
+            .input-group-btn:first-child>.btn,
+            .input-group-btn:first-child>.btn-group>.btn,
+            .input-group-btn:first-child>.dropdown-toggle,
+            .input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle),
+            .input-group-btn:last-child>.btn-group:not(:last-child)>.btn {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0
+            }
+            
+            .input-group .form-control:last-child,
+            .input-group-addon:last-child,
+            .input-group-btn:last-child>.btn,
+            .input-group-btn:last-child>.btn-group>.btn,
+            .input-group-btn:last-child>.dropdown-toggle,
+            .input-group-btn:first-child>.btn:not(:first-child),
+            .input-group-btn:first-child>.btn-group:not(:first-child)>.btn {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0
+            }
+            
+            .input-group-btn {
+                position: relative;
+                font-size: 0;
+                white-space: nowrap
+            }
+            
+            .input-group-btn>.btn {
+                position: relative
+            }
+            
+            .input-group-btn>.btn+.btn {
+                margin-left: -1px
+            }
+            
+            .input-group-btn:last-child>.btn,
+            .input-group-btn:last-child>.btn-group {
+                z-index: 2;
+                margin-left: -1px
+            }
+            
+            .navbar-fixed-top,
+            .navbar-fixed-bottom {
+                position: fixed;
+                right: 0;
+                left: 0;
+                z-index: 1030
+            }
+            
+            .navbar-fixed-top .navbar-collapse,
+            .navbar-fixed-bottom .navbar-collapse {
+                max-height: 340px
+            }
+            
+            .navbar-fixed-top {
+                top: 0;
+                border-width: 0 0 1px
+            }
+            
+            .container>.navbar-header,
+            .container-fluid>.navbar-header,
+            .container>.navbar-collapse,
+            .container-fluid>.navbar-collapse {
+                margin-right: -15px;
+                margin-left: -15px
+            }
+            
+            .navbar-brand {
+                float: left;
+                height: 60px;
+                padding: 19.5px 15px;
+                font-size: 19px;
+                line-height: 21px
+            }
+            
+            .navbar-toggle {
+                position: relative;
+                float: right;
+                padding: 9px 10px;
+                margin-right: 15px;
+                margin-top: 13px;
+                margin-bottom: 13px;
+                background-color: transparent;
+                background-image: none;
+                border: 1px solid transparent;
+                border-radius: 4px
+            }
+            
+            .navbar-toggle .icon-bar {
+                display: block;
+                width: 22px;
+                height: 2px;
+                border-radius: 1px
+            }
+            
+            .navbar-toggle .icon-bar+.icon-bar {
+                margin-top: 4px
+            }
+            
+            .navbar-default {
+                background-color: #2c3e50;
+                border-color: transparent
+            }
+            
+            .navbar-default .navbar-brand {
+                color: #ffffff
+            }
+            
+            .navbar-default .navbar-toggle {
+                border-color: #1a242f
+            }
+            
+            .navbar-default .navbar-toggle .icon-bar {
+                background-color: #ffffff
+            }
+            
+            .navbar-default .navbar-collapse,
+            .navbar-default .navbar-form {
+                border-color: transparent
+            }
+            
+            .alert-success {
+                color: #ffffff;
+                background-color: #18bc9c;
+                border-color: #18bc9c
+            }
+            
+            .alert-info {
+                color: #ffffff;
+                background-color: #3498db;
+                border-color: #3498db
+            }
+            
+            .alert-warning {
+                color: #ffffff;
+                background-color: #f39c12;
+                border-color: #f39c12
+            }
+            
+            .alert-danger {
+                color: #ffffff;
+                background-color: #e74c3c;
+                border-color: #e74c3c
+            }
+            
+            .panel {
+                margin-bottom: 21px;
+                background-color: #ffffff;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05)
+            }
+            
+            .panel-heading {
+                padding: 10px 15px;
+                border-bottom: 1px solid transparent;
+                border-top-left-radius: 3px;
+                border-top-right-radius: 3px
+            }
+            
+            .panel-title {
+                margin-top: 0;
+                margin-bottom: 0;
+                font-size: 17px;
+                color: inherit
+            }
+            
+            .panel-title>a,
+            .panel-title>small,
+            .panel-title>.small,
+            .panel-title>small>a,
+            .panel-title>.small>a {
+                color: inherit
+            }
+            
+            .panel-footer {
+                padding: 10px 15px;
+                background-color: #ecf0f1;
+                border-top: 1px solid #ecf0f1;
+                border-bottom-right-radius: 3px;
+                border-bottom-left-radius: 3px
+            }
+            
+            .panel-group {
+                margin-bottom: 21px
+            }
+            
+            .panel-group .panel {
+                margin-bottom: 0;
+                border-radius: 4px
+            }
+            
+            .panel-group .panel+.panel {
+                margin-top: 5px
+            }
+            
+            .panel-group .panel-heading {
+                border-bottom: 0
+            }
+            
+            .panel-default {
+                border-color: #ecf0f1
+            }
+            
+            .panel-default>.panel-heading {
+                color: #2c3e50;
+                background-color: #ecf0f1;
+                border-color: #ecf0f1
+            }
+            
+            .well {
+                min-height: 20px;
+                padding: 19px;
+                margin-bottom: 20px;
+                background-color: #ecf0f1;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05)
+            }
+            
+            .modal {
+                position: fixed;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                z-index: 1050;
+                display: none;
+                overflow: hidden;
+                -webkit-overflow-scrolling: touch;
+                outline: 0
+            }
+            
+            .clearfix:before,
+            .clearfix:after,
+            .dl-horizontal dd:before,
+            .dl-horizontal dd:after,
+            .container:before,
+            .container:after,
+            .container-fluid:before,
+            .container-fluid:after,
+            .row:before,
+            .row:after,
+            .form-horizontal .form-group:before,
+            .form-horizontal .form-group:after,
+            .btn-toolbar:before,
+            .btn-toolbar:after,
+            .btn-group-vertical>.btn-group:before,
+            .btn-group-vertical>.btn-group:after,
+            .nav:before,
+            .nav:after,
+            .navbar:before,
+            .navbar:after,
+            .navbar-header:before,
+            .navbar-header:after,
+            .navbar-collapse:before,
+            .navbar-collapse:after,
+            .pager:before,
+            .pager:after,
+            .panel-body:before,
+            .panel-body:after,
+            .modal-header:before,
+            .modal-header:after,
+            .modal-footer:before,
+            .modal-footer:after {
+                display: table;
+                content: " "
+            }
+            
+            .clearfix:after,
+            .dl-horizontal dd:after,
+            .container:after,
+            .container-fluid:after,
+            .row:after,
+            .form-horizontal .form-group:after,
+            .btn-toolbar:after,
+            .btn-group-vertical>.btn-group:after,
+            .nav:after,
+            .navbar:after,
+            .navbar-header:after,
+            .navbar-collapse:after,
+            .pager:after,
+            .panel-body:after,
+            .modal-header:after,
+            .modal-footer:after {
+                clear: both
+            }
+            
+            .center-block {
+                display: block;
+                margin-right: auto;
+                margin-left: auto
+            }
+            
+            .pull-right {
+                float: right !important
+            }
+            
+            .pull-left {
+                float: left !important
+            }
+            
+            .hidden {
+                display: none !important
+            }
+            
+            @media (max-width: 767px) {
+                .hidden-xs {
+                    display: none !important
+                }
+            }
+            
+            .navbar-brand {
+                line-height: 1
+            }
+            
+            .btn {
+                border-width: 2px
+            }
+        </style>
         <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
         {% block stylesheets %}{% endblock %}
 

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -20,12 +20,730 @@
         </title>
 
         <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <!-- <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" /> -->
         <link href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/toastr/build/toastr.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <style id="style-javascript"></style>
+        <style>
+            html {
+                font-family: sans-serif;
+                -ms-text-size-adjust: 100%;
+                -webkit-text-size-adjust: 100%
+            }
+            
+            body {
+                margin: 0
+            }
+            
+            article,
+            aside,
+            details,
+            figcaption,
+            figure,
+            footer,
+            header,
+            hgroup,
+            main,
+            menu,
+            nav,
+            section,
+            summary {
+                display: block
+            }
+            
+            a {
+                background-color: transparent
+            }
+            
+            a:active,
+            a:hover {
+                outline: 0
+            }
+            
+            b,
+            strong {
+                font-weight: bold
+            }
+            
+            svg:not(:root) {
+                overflow: hidden
+            }
+            
+            hr {
+                box-sizing: content-box;
+                height: 0
+            }
+            
+            button,
+            input,
+            optgroup,
+            select,
+            textarea {
+                color: inherit;
+                font: inherit;
+                margin: 0
+            }
+            
+            button {
+                overflow: visible
+            }
+            
+            button,
+            select {
+                text-transform: none
+            }
+            
+            button,
+            html input[type="button"],
+            input[type="reset"],
+            input[type="submit"] {
+                -webkit-appearance: button;
+                cursor: pointer
+            }
+            
+            input {
+                line-height: normal
+            }
+            
+            table {
+                border-collapse: collapse;
+                border-spacing: 0
+            }
+            
+            * {
+                box-sizing: border-box
+            }
+            
+            *:before,
+            *:after {
+                box-sizing: border-box
+            }
+            
+            html {
+                font-size: 10px;
+                -webkit-tap-highlight-color: rgba(0, 0, 0, 0)
+            }
+            
+            body {
+                font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-size: 15px;
+                line-height: 1.42857143;
+                color: #2c3e50;
+                background-color: #ffffff
+            }
+            
+            input,
+            button,
+            select,
+            textarea {
+                font-family: inherit;
+                font-size: inherit;
+                line-height: inherit
+            }
+            
+            a {
+                color: #18bc9c;
+                text-decoration: none
+            }
+            
+            a:hover,
+            a:focus {
+                color: #18bc9c;
+                text-decoration: underline
+            }
+            
+            hr {
+                margin-top: 21px;
+                margin-bottom: 21px;
+                border: 0;
+                border-top: 1px solid #ecf0f1
+            }
+            
+            .sr-only {
+                position: absolute;
+                width: 1px;
+                height: 1px;
+                padding: 0;
+                margin: -1px;
+                overflow: hidden;
+                clip: rect(0, 0, 0, 0);
+                border: 0
+            }
+            
+            [role="button"] {
+                cursor: pointer
+            }
+            
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6,
+            .h1,
+            .h2,
+            .h3,
+            .h4,
+            .h5,
+            .h6 {
+                font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+                font-weight: 400;
+                line-height: 1.1;
+                color: inherit
+            }
+            
+            h1,
+            .h1,
+            h2,
+            .h2,
+            h3,
+            .h3 {
+                margin-top: 21px;
+                margin-bottom: 10.5px
+            }
+            
+            h4,
+            .h4,
+            h5,
+            .h5,
+            h6,
+            .h6 {
+                margin-top: 10.5px;
+                margin-bottom: 10.5px
+            }
+            
+            h3,
+            .h3 {
+                font-size: 26px
+            }
+            
+            h4,
+            .h4 {
+                font-size: 19px
+            }
+            
+            .text-right {
+                text-align: right
+            }
+            
+            .container-fluid {
+                padding-right: 15px;
+                padding-left: 15px;
+                margin-right: auto;
+                margin-left: auto
+            }
+            
+            .row {
+                margin-right: -15px;
+                margin-left: -15px
+            }
+            
+            .col-xs-1,
+            .col-sm-1,
+            .col-md-1,
+            .col-lg-1,
+            .col-xs-2,
+            .col-sm-2,
+            .col-md-2,
+            .col-lg-2,
+            .col-xs-3,
+            .col-sm-3,
+            .col-md-3,
+            .col-lg-3,
+            .col-xs-4,
+            .col-sm-4,
+            .col-md-4,
+            .col-lg-4,
+            .col-xs-5,
+            .col-sm-5,
+            .col-md-5,
+            .col-lg-5,
+            .col-xs-6,
+            .col-sm-6,
+            .col-md-6,
+            .col-lg-6,
+            .col-xs-7,
+            .col-sm-7,
+            .col-md-7,
+            .col-lg-7,
+            .col-xs-8,
+            .col-sm-8,
+            .col-md-8,
+            .col-lg-8,
+            .col-xs-9,
+            .col-sm-9,
+            .col-md-9,
+            .col-lg-9,
+            .col-xs-10,
+            .col-sm-10,
+            .col-md-10,
+            .col-lg-10,
+            .col-xs-11,
+            .col-sm-11,
+            .col-md-11,
+            .col-lg-11,
+            .col-xs-12,
+            .col-sm-12,
+            .col-md-12,
+            .col-lg-12 {
+                position: relative;
+                min-height: 1px;
+                padding-right: 15px;
+                padding-left: 15px
+            }
+            
+            .col-xs-1,
+            .col-xs-2,
+            .col-xs-3,
+            .col-xs-4,
+            .col-xs-5,
+            .col-xs-6,
+            .col-xs-7,
+            .col-xs-8,
+            .col-xs-9,
+            .col-xs-10,
+            .col-xs-11,
+            .col-xs-12 {
+                float: left
+            }
+            
+            .col-xs-12 {
+                width: 100%
+            }
+            
+            .col-xs-10 {
+                width: 83.33333333%
+            }
+            
+            .col-xs-2 {
+                width: 16.66666667%
+            }
+            
+            .form-control {
+                display: block;
+                width: 100%;
+                height: 45px;
+                padding: 10px 15px;
+                font-size: 15px;
+                line-height: 1.42857143;
+                color: #2c3e50;
+                background-color: #ffffff;
+                background-image: none;
+                border: 1px solid #dce4ec;
+                border-radius: 4px;
+                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+                transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s
+            }
+            
+            .form-control::-webkit-input-placeholder {
+                color: #acb6c0
+            }
+            
+            .btn {
+                display: inline-block;
+                margin-bottom: 0;
+                font-weight: normal;
+                text-align: center;
+                white-space: nowrap;
+                vertical-align: middle;
+                -ms-touch-action: manipulation;
+                touch-action: manipulation;
+                cursor: pointer;
+                background-image: none;
+                border: 1px solid transparent;
+                padding: 10px 15px;
+                font-size: 15px;
+                line-height: 1.42857143;
+                border-radius: 4px;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+                user-select: none
+            }
+            
+            .btn-default {
+                color: #ffffff;
+                background-color: #95a5a6;
+                border-color: #95a5a6
+            }
+            
+            .btn-primary {
+                color: #ffffff;
+                background-color: #2c3e50;
+                border-color: #2c3e50
+            }
+            
+            .fade {
+                opacity: 0;
+                transition: opacity 0.15s linear
+            }
+            
+            .collapse {
+                display: none
+            }
+            
+            .caret {
+                display: inline-block;
+                width: 0;
+                height: 0;
+                margin-left: 2px;
+                vertical-align: middle;
+                border-top: 4px dashed;
+                border-top: 4px solid \9;
+                border-right: 4px solid transparent;
+                border-left: 4px solid transparent
+            }
+            
+            .input-group {
+                position: relative;
+                display: table;
+                border-collapse: separate
+            }
+            
+            .input-group .form-control {
+                position: relative;
+                z-index: 2;
+                float: left;
+                width: 100%;
+                margin-bottom: 0
+            }
+            
+            .input-group-addon,
+            .input-group-btn,
+            .input-group .form-control {
+                display: table-cell
+            }
+            
+            .input-group-addon,
+            .input-group-btn {
+                width: 1%;
+                white-space: nowrap;
+                vertical-align: middle
+            }
+            
+            .input-group .form-control:first-child,
+            .input-group-addon:first-child,
+            .input-group-btn:first-child>.btn,
+            .input-group-btn:first-child>.btn-group>.btn,
+            .input-group-btn:first-child>.dropdown-toggle,
+            .input-group-btn:last-child>.btn:not(:last-child):not(.dropdown-toggle),
+            .input-group-btn:last-child>.btn-group:not(:last-child)>.btn {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0
+            }
+            
+            .input-group .form-control:last-child,
+            .input-group-addon:last-child,
+            .input-group-btn:last-child>.btn,
+            .input-group-btn:last-child>.btn-group>.btn,
+            .input-group-btn:last-child>.dropdown-toggle,
+            .input-group-btn:first-child>.btn:not(:first-child),
+            .input-group-btn:first-child>.btn-group:not(:first-child)>.btn {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0
+            }
+            
+            .input-group-btn {
+                position: relative;
+                font-size: 0;
+                white-space: nowrap
+            }
+            
+            .input-group-btn>.btn {
+                position: relative
+            }
+            
+            .input-group-btn>.btn+.btn {
+                margin-left: -1px
+            }
+            
+            .input-group-btn:last-child>.btn,
+            .input-group-btn:last-child>.btn-group {
+                z-index: 2;
+                margin-left: -1px
+            }
+            
+            .navbar-fixed-top,
+            .navbar-fixed-bottom {
+                position: fixed;
+                right: 0;
+                left: 0;
+                z-index: 1030
+            }
+            
+            .navbar-fixed-top .navbar-collapse,
+            .navbar-fixed-bottom .navbar-collapse {
+                max-height: 340px
+            }
+            
+            .navbar-fixed-top {
+                top: 0;
+                border-width: 0 0 1px
+            }
+            
+            .container>.navbar-header,
+            .container-fluid>.navbar-header,
+            .container>.navbar-collapse,
+            .container-fluid>.navbar-collapse {
+                margin-right: -15px;
+                margin-left: -15px
+            }
+            
+            .navbar-brand {
+                float: left;
+                height: 60px;
+                padding: 19.5px 15px;
+                font-size: 19px;
+                line-height: 21px
+            }
+            
+            .navbar-toggle {
+                position: relative;
+                float: right;
+                padding: 9px 10px;
+                margin-right: 15px;
+                margin-top: 13px;
+                margin-bottom: 13px;
+                background-color: transparent;
+                background-image: none;
+                border: 1px solid transparent;
+                border-radius: 4px
+            }
+            
+            .navbar-toggle .icon-bar {
+                display: block;
+                width: 22px;
+                height: 2px;
+                border-radius: 1px
+            }
+            
+            .navbar-toggle .icon-bar+.icon-bar {
+                margin-top: 4px
+            }
+            
+            .navbar-default {
+                background-color: #2c3e50;
+                border-color: transparent
+            }
+            
+            .navbar-default .navbar-brand {
+                color: #ffffff
+            }
+            
+            .navbar-default .navbar-toggle {
+                border-color: #1a242f
+            }
+            
+            .navbar-default .navbar-toggle .icon-bar {
+                background-color: #ffffff
+            }
+            
+            .navbar-default .navbar-collapse,
+            .navbar-default .navbar-form {
+                border-color: transparent
+            }
+            
+            .alert-success {
+                color: #ffffff;
+                background-color: #18bc9c;
+                border-color: #18bc9c
+            }
+            
+            .alert-info {
+                color: #ffffff;
+                background-color: #3498db;
+                border-color: #3498db
+            }
+            
+            .alert-warning {
+                color: #ffffff;
+                background-color: #f39c12;
+                border-color: #f39c12
+            }
+            
+            .alert-danger {
+                color: #ffffff;
+                background-color: #e74c3c;
+                border-color: #e74c3c
+            }
+            
+            .panel {
+                margin-bottom: 21px;
+                background-color: #ffffff;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05)
+            }
+            
+            .panel-heading {
+                padding: 10px 15px;
+                border-bottom: 1px solid transparent;
+                border-top-left-radius: 3px;
+                border-top-right-radius: 3px
+            }
+            
+            .panel-title {
+                margin-top: 0;
+                margin-bottom: 0;
+                font-size: 17px;
+                color: inherit
+            }
+            
+            .panel-title>a,
+            .panel-title>small,
+            .panel-title>.small,
+            .panel-title>small>a,
+            .panel-title>.small>a {
+                color: inherit
+            }
+            
+            .panel-footer {
+                padding: 10px 15px;
+                background-color: #ecf0f1;
+                border-top: 1px solid #ecf0f1;
+                border-bottom-right-radius: 3px;
+                border-bottom-left-radius: 3px
+            }
+            
+            .panel-group {
+                margin-bottom: 21px
+            }
+            
+            .panel-group .panel {
+                margin-bottom: 0;
+                border-radius: 4px
+            }
+            
+            .panel-group .panel+.panel {
+                margin-top: 5px
+            }
+            
+            .panel-group .panel-heading {
+                border-bottom: 0
+            }
+            
+            .panel-default {
+                border-color: #ecf0f1
+            }
+            
+            .panel-default>.panel-heading {
+                color: #2c3e50;
+                background-color: #ecf0f1;
+                border-color: #ecf0f1
+            }
+            
+            .well {
+                min-height: 20px;
+                padding: 19px;
+                margin-bottom: 20px;
+                background-color: #ecf0f1;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05)
+            }
+            
+            .modal {
+                position: fixed;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                z-index: 1050;
+                display: none;
+                overflow: hidden;
+                -webkit-overflow-scrolling: touch;
+                outline: 0
+            }
+            
+            .clearfix:before,
+            .clearfix:after,
+            .dl-horizontal dd:before,
+            .dl-horizontal dd:after,
+            .container:before,
+            .container:after,
+            .container-fluid:before,
+            .container-fluid:after,
+            .row:before,
+            .row:after,
+            .form-horizontal .form-group:before,
+            .form-horizontal .form-group:after,
+            .btn-toolbar:before,
+            .btn-toolbar:after,
+            .btn-group-vertical>.btn-group:before,
+            .btn-group-vertical>.btn-group:after,
+            .nav:before,
+            .nav:after,
+            .navbar:before,
+            .navbar:after,
+            .navbar-header:before,
+            .navbar-header:after,
+            .navbar-collapse:before,
+            .navbar-collapse:after,
+            .pager:before,
+            .pager:after,
+            .panel-body:before,
+            .panel-body:after,
+            .modal-header:before,
+            .modal-header:after,
+            .modal-footer:before,
+            .modal-footer:after {
+                display: table;
+                content: " "
+            }
+            
+            .clearfix:after,
+            .dl-horizontal dd:after,
+            .container:after,
+            .container-fluid:after,
+            .row:after,
+            .form-horizontal .form-group:after,
+            .btn-toolbar:after,
+            .btn-group-vertical>.btn-group:after,
+            .nav:after,
+            .navbar:after,
+            .navbar-header:after,
+            .navbar-collapse:after,
+            .pager:after,
+            .panel-body:after,
+            .modal-header:after,
+            .modal-footer:after {
+                clear: both
+            }
+            
+            .center-block {
+                display: block;
+                margin-right: auto;
+                margin-left: auto
+            }
+            
+            .pull-right {
+                float: right !important
+            }
+            
+            .pull-left {
+                float: left !important
+            }
+            
+            .hidden {
+                display: none !important
+            }
+            
+            @media (max-width: 767px) {
+                .hidden-xs {
+                    display: none !important
+                }
+            }
+            
+            .navbar-brand {
+                line-height: 1
+            }
+            
+            .btn {
+                border-width: 2px
+            }
+        </style>
         {% appearance_app_templates template_name='head' %}
         {% block stylesheets %}{% endblock %}
     </head>


### PR DESCRIPTION
Resolves #27 
I only included covered code from bootstrap.min.css in root.html and base_plain.html. I eliminated render-blocking resources (bootstrap.min.css), since previously over 90% of the code was not covered.
Improved performance score from 43 to 53.
