### PR TITLE
add meta description in template

### DIFF
--- a/mayan/apps/appearance/templates/appearance/base_plain.html
+++ b/mayan/apps/appearance/templates/appearance/base_plain.html
@@ -10,6 +10,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
     <head>
+        <meta name="description" content="meta description">
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />


### PR DESCRIPTION
Lighthouse gave 89 on SEO, and warned that there was no meta description. This commit resolves the issue by adding the meta description tag in base templates, and improves the score to 100 (on my lighthouse instance)