### PR TITLE
Sufficiently increased contrast ratio between background and foreground colors in "Create new tag"

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -113,7 +113,7 @@
                 {% else %}
                     {% render_field field class+="form-control" %}
                 {% endif %}
-                {% if field.help_text and not form_hide_help_text %}<p class="help-block">{{ field.help_text|safe }}</p>{% endif %}
+                {% if field.help_text and not form_hide_help_text %}<p class="help-block" style="color:#000033">{{ field.help_text|safe }}</p>{% endif %}
             </div>
         {% endfor %}
 {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -83,7 +83,7 @@
                         {% if submit_label %}{{ submit_label }}{% else %}{% if form.instance %}{% trans 'Save' %}{% else %}{% trans 'Submit' %}{% endif %}{% endif %}
                     </button>
                     {% if previous %}
-                          &nbsp;<a class="btn btn-default" onclick='history.back();'>
+                          &nbsp;<a class="btn btn-default" onclick='history.back();' style="background-color:#cc3300">
                             <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{% else %}{% trans 'Cancel' %}{% endif %}
                           </a>
                     {% endif %}


### PR DESCRIPTION
The original contrast ratio between background and foreground colors in "Create new tag" page was too low. I changed the "help-block" text color to dark blue and the color of the Cancel button to red to sufficiently increase the contrast ratio. The lighthouse score for accessibility has increased from 85 to 87 after these fixes. #25 