### PR TITLE
Added discernible name to notification & message icon link in the top navigation bar; Added discernible name to panel title link; Improved accessibility score from 89 to 91

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -10,6 +10,7 @@
             <h4 class="panel-title">
                 <a class="disabled" href="">
                     <i class="fa fa-angle-double-left"></i>
+                    Panel Title
                 </a>
             </h4>
         </div>

--- a/mayan/apps/events/links.py
+++ b/mayan/apps/events/links.py
@@ -77,6 +77,6 @@ link_object_event_types_user_subcriptions_list = Link(
 )
 link_user_notifications_list = Link(
     badge_text=get_unread_notification_count,
-    icon=icon_user_notifications_list, text='',
+    icon=icon_user_notifications_list, text='User Notifications List',
     view='events:user_notifications_list'
 )

--- a/mayan/apps/messaging/links.py
+++ b/mayan/apps/messaging/links.py
@@ -47,7 +47,7 @@ link_message_single_delete = Link(
 )
 link_message_list = Link(
     badge_text=get_unread_message_count, icon=icon_message_list,
-    text='', view='messaging:message_list'
+    text='Message List', view='messaging:message_list'
 )
 link_message_single_mark_read = Link(
     args='object.pk', conditional_disable=condition_is_read,


### PR DESCRIPTION
Resolves #4 .

Adding a discernible name ("User Notifications List") to the notification icon link in the top navigation bar.

Adding a discernible name ("Message List") to the message icon link in the top navigation bar.

Adding a discernible name ("Panel Title") to the link for the panel title in `menu_main.html`.

The Accessibility score, as reported by Lighthouse, increased from 89 to 91 as a result of this change. In particular, the "Links do not have a discernible name" warning is now resolved. You can learn more about this warning [here](https://web.dev/link-name/?utm_source=lighthouse&utm_medium=devtools).