### PR TITLE
make the help text have higher contrast in forms

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -113,7 +113,7 @@
                 {% else %}
                     {% render_field field class+="form-control" %}
                 {% endif %}
-                {% if field.help_text and not form_hide_help_text %}<p class="help-block">{{ field.help_text|safe }}</p>{% endif %}
+                {% if field.help_text and not form_hide_help_text %}<p class="help-block" style="color:darkslategray">{{ field.help_text|safe }}</p>{% endif %}
             </div>
         {% endfor %}
 {% endif %}


### PR DESCRIPTION
Change the text color in forms to have higher contrast with the background. This improves the lighthouse accessibility score on the current user details page from 88 to 92
Resolves #36 