### PR TITLE
Increase contrast of text/background on Edit User Details page

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -113,7 +113,7 @@
                 {% else %}
                     {% render_field field class+="form-control" %}
                 {% endif %}
-                {% if field.help_text and not form_hide_help_text %}<p class="help-block">{{ field.help_text|safe }}</p>{% endif %}
+                {% if field.help_text and not form_hide_help_text %}<p class="help-block" style="color:#000000">{{ field.help_text|safe }}</p>{% endif %}
             </div>
         {% endfor %}
 {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_subtemplate.html
@@ -83,7 +83,7 @@
                         {% if submit_label %}{{ submit_label }}{% else %}{% if form.instance %}{% trans 'Save' %}{% else %}{% trans 'Submit' %}{% endif %}{% endif %}
                     </button>
                     {% if previous %}
-                          &nbsp;<a class="btn btn-default" onclick='history.back();'>
+                          &nbsp;<a class="btn btn-default" onclick='history.back();' style="color:#000000">
                             <i class="fa fa-times"></i> {% if cancel_label %}{{ cancel_label }}{% else %}{% trans 'Cancel' %}{% endif %}
                           </a>
                     {% endif %}


### PR DESCRIPTION
This commit improves the lighthouse accessibility score on the "Edit User Details" page from 89 to 91.
Resolves [#39](https://github.com/CMU-313/Mayan-EDMS/issues/39).

Changes included:
- Change help text to black.
- Change color of 'Cancel' button text to black.