### PR TITLE
Remove toastr.min.css to improve page loading performance

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -23,7 +23,7 @@
         <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/toastr/build/toastr.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <!-- <link href="{% static 'appearance/node_modules/toastr/build/toastr.min.css' %}" media="screen" rel="stylesheet" type="text/css" /> -->
         <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <style id="style-javascript"></style>
         {% appearance_app_templates template_name='head' %}


### PR DESCRIPTION
Resolved https://github.com/CMU-313/Mayan-EDMS/issues/42.
Remove link reference to `toastr.min.css` because styling of `toastr` is replaced with `bootstrap alert` and all content of this file is unused according to Coverage tab of Google Chrome. This commit improves the performance score from 46 to 67.