### PR TITLE
Eliminate render-blocking resources

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,22 +13,19 @@ x-mayan-container:
     # MAYAN_CELERY_BROKER_URL: amqp://${MAYAN_RABBITMQ_USER:-mayan}:${MAYAN_RABBITMQ_PASSWORD:-mayanrabbitpass}@rabbitmq:5672/${MAYAN_RABBITMQ_VHOST:-mayan}
     # To use RabbitMQ as broker, disable Redis as broker
     PYTHONDONTWRITEBYTECODE: 1
-    MAYAN_CELERY_BROKER_URL: redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/0
-    MAYAN_CELERY_RESULT_BACKEND: redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/1
-    MAYAN_DATABASES: "{'default':{'ENGINE':'django.db.backends.postgresql','NAME':'${MAYAN_DATABASE_NAME:-mayan}','PASSWORD':'${MAYAN_DATABASE_PASSWORD:-mayandbpass}','USER':'${MAYAN_DATABASE_USER:-mayan}','HOST':'${MAYAN_DATABASE_HOST:-postgresql}'}}"
-    MAYAN_DOCKER_WAIT: "${MAYAN_DATABASE_HOST:-postgresql}:5432 redis:6379"
+    MAYAN_CELERY_BROKER_URL: redis://:mayanredispassword@172.17.0.1:6379/0
+    MAYAN_CELERY_RESULT_BACKEND: redis://:mayanredispassword@172.17.0.1:6379/1
+    MAYAN_DATABASES: "{'default':{'ENGINE':'django.db.backends.postgresql','NAME':'mayan','PASSWORD':'mayanuserpass','USER':'mayan','HOST':'172.17.0.1'}}"
     MAYAN_LOCK_MANAGER_BACKEND: mayan.apps.lock_manager.backends.redis_lock.RedisLock
-    MAYAN_LOCK_MANAGER_BACKEND_ARGUMENTS: "{'redis_url':'redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/2'}"
+    MAYAN_LOCK_MANAGER_BACKEND_ARGUMENTS: "{'redis_url':'redis://:mayanredispassword@172.17.0.1:6379/2'}"
     # Replace with the line below when using RabbitMQ
     # MAYAN_DOCKER_WAIT: "${MAYAN_DATABASE_HOST:-postgresql}:5432 redis:6379 rabbitmq:5672"
-  image: ${MAYAN_DOCKER_IMAGE_NAME:-mayanedms/mayanedms}:${MAYAN_DOCKER_IMAGE_TAG:-4.0.7}
+  image: mayanedms/mayanedms:4.0.7
   networks:
     - bridge
   restart: unless-stopped
   volumes:
-    - ${PWD}/data/app:/var/lib/mayan
-    - ${PWD}/mayan/apps/appearance/static/appearance/css:/opt/mayan-edms/static/appearance/css
-    - ${PWD}/mayan:/opt/mayan-edms/lib/python3.7/site-packages/mayan
+    - /docker-volumes/mayan-edms/media:/var/lib/mayan
     # Optional volumes to access external data like staging or watch folders
     # - /opt/staging_files:/staging_files
     # - /opt/watch_folder:/watch_folder
@@ -59,18 +56,18 @@ services:
       - "-c"
       - "work_mem=8MB"
     environment:
-      POSTGRES_DB: ${MAYAN_DATABASE_NAME:-mayan}
-      POSTGRES_PASSWORD: ${MAYAN_DATABASE_PASSWORD:-mayandbpass}
-      POSTGRES_USER: ${MAYAN_DATABASE_USER:-mayan}
-    image: postgres:${MAYAN_DOCKER_POSTGRES_TAG:-10.15-alpine}
+      POSTGRES_DB: mayan
+      POSTGRES_PASSWORD: mayanuserpass
+      POSTGRES_USER: mayan
+    image: postgres:10.15-alpine
     networks:
       - bridge
     # Disable to allow external access to the database.    
-    # ports:
-    #  - "5432:5432"
+    ports:
+      - "5432:5432"
     restart: unless-stopped
     volumes:
-      - ${PWD}/data/postgres:/var/lib/postgresql/data
+      - /docker-volumes/mayan-edms/postgres:/var/lib/postgresql/data
 
   redis:
     command:
@@ -94,125 +91,127 @@ services:
     image: redis:${MAYAN_DOCKER_REDIS_TAG:-6.0-alpine}
     networks:
       - bridge
+    ports:
+      - "6379:6379"
     restart: unless-stopped
     volumes:
-      - ${PWD}/data/redis:/data
+      - /docker-volumes/mayan-edms/redis:/data
 
-  # Celery flower a monitor for Celery
-  celery_flower:
-    <<: *mayan-container
-    command:
-      - run_celery
-      - flower
-    ports:
-      - "5555:5555"
-    profiles:
-      - celery_flower
+  # # Celery flower a monitor for Celery
+  # celery_flower:
+  #   <<: *mayan-container
+  #   command:
+  #     - run_celery
+  #     - flower
+  #   ports:
+  #     - "5555:5555"
+  #   profiles:
+  #     - celery_flower
 
-  # Run a frontend gunicorn container
-  frontend:
-    <<: *mayan-container
-    command:
-      - run_worker
-      - fast
-    ports:
-      - "81:8000"
-    profiles:
-      - extra_frontend
+#   # Run a frontend gunicorn container
+#   frontend:
+#     <<: *mayan-container
+#     command:
+#       - run_worker
+#       - fast
+#     ports:
+#       - "81:8000"
+#     profiles:
+#       - extra_frontend
 
-  # Enable to run standalone workers
-  mountindex:
-    <<: *mayan-container
-    cap_add:
-      - SYS_ADMIN
-    devices:
-      - "/dev/fuse:/dev/fuse"
-    entrypoint:
-      - /bin/bash
-      - -c
-      - 'mkdir --parents /mnt/index && chown mayan:mayan /mnt/index && /usr/local/bin/entrypoint.sh run_command "mountindex --allow-other creation_date /mnt/index"'  # Replace "creation_date" with the index of your choice.
-    profiles:
-      - mountindex
-    security_opt:
-      - apparmor:unconfined
-    volumes:
-      - type: bind
-        source: /mnt/mayan_indexes/creation_date  # Host location where the index will show up.
-        target: /mnt/index  # Location inside the container where the index will be mounted. Must the same is in the "entrypoint" section.
-        bind:
-          propagation: shared
+#   # Enable to run standalone workers
+#   mountindex:
+#     <<: *mayan-container
+#     cap_add:
+#       - SYS_ADMIN
+#     devices:
+#       - "/dev/fuse:/dev/fuse"
+#     entrypoint:
+#       - /bin/bash
+#       - -c
+#       - 'mkdir --parents /mnt/index && chown mayan:mayan /mnt/index && /usr/local/bin/entrypoint.sh run_command "mountindex --allow-other creation_date /mnt/index"'  # Replace "creation_date" with the index of your choice.
+#     profiles:
+#       - mountindex
+#     security_opt:
+#       - apparmor:unconfined
+#     volumes:
+#       - type: bind
+#         source: /mnt/mayan_indexes/creation_date  # Host location where the index will show up.
+#         target: /mnt/index  # Location inside the container where the index will be mounted. Must the same is in the "entrypoint" section.
+#         bind:
+#           propagation: shared
 
-  # Run a separate class A worker
-  worker_a:
-    <<: *mayan-container
-    command:
-      - run_worker
-      - worker_a
-    profiles:
-      - extra_worker_a
+#   # Run a separate class A worker
+#   worker_a:
+#     <<: *mayan-container
+#     command:
+#       - run_worker
+#       - worker_a
+#     profiles:
+#       - extra_worker_a
 
-  # Run a separate class B worker
-  worker_b:
-    <<: *mayan-container
-    command:
-      - run_worker
-      - worker_b
-    profiles:
-      - extra_worker_b
+#   # Run a separate class B worker
+#   worker_b:
+#     <<: *mayan-container
+#     command:
+#       - run_worker
+#       - worker_b
+#     profiles:
+#       - extra_worker_b
 
-  # Run a separate class C worker
-  worker_c:
-    <<: *mayan-container
-    command:
-      - run_worker
-      - worker_c
-    profiles:
-      - extra_worker_c
+#   # Run a separate class C worker
+#   worker_c:
+#     <<: *mayan-container
+#     command:
+#       - run_worker
+#       - worker_c
+#     profiles:
+#       - extra_worker_c
 
-  # Run a separate class D worker
-  worker_d:
-    <<: *mayan-container
-    command:
-      - run_worker
-      - worker_d
-    profiles:
-      - extra_worker_d
+#   # Run a separate class D worker
+#   worker_d:
+#     <<: *mayan-container
+#     command:
+#       - run_worker
+#       - worker_d
+#     profiles:
+#       - extra_worker_d
 
-  # Optional services
+#   # Optional services
 
-  traefik:
-    container_name: "traefik"
-    command:
-      #- "--log.level=DEBUG"
-      - "--api.insecure=true"
-      - "--providers.docker=true"
-      - "--providers.docker.exposedbydefault=false"
-      - "--entrypoints.web.address=:80"
-    image: "traefik:v2.4"
-    ports:
-      - "80:80"
-      - "8080:8080"
-    profiles:
-      - traefik
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+#   traefik:
+#     container_name: "traefik"
+#     command:
+#       #- "--log.level=DEBUG"
+#       - "--api.insecure=true"
+#       - "--providers.docker=true"
+#       - "--providers.docker.exposedbydefault=false"
+#       - "--entrypoints.web.address=:80"
+#     image: "traefik:v2.4"
+#     ports:
+#       - "80:80"
+#       - "8080:8080"
+#     profiles:
+#       - traefik
+#     volumes:
+#       - /var/run/docker.sock:/var/run/docker.sock:ro
 
-  # Enable to use RabbitMQ
-  # rabbitmq:
-  #   image: rabbitmq:${MAYAN_DOCKER_RABBITMQ_TAG:-3.8-alpine}
-  #   environment:
-  #     RABBITMQ_DEFAULT_USER: ${MAYAN_RABBITMQ_USER:-mayan}
-  #     RABBITMQ_DEFAULT_PASS: ${MAYAN_RABBITMQ_PASSWORD:-mayanrabbitpass}
-  #     RABBITMQ_DEFAULT_VHOST: ${MAYAN_RABBITMQ_VHOST:-mayan}
-  #   networks:
-  #     - bridge
-  #   restart: unless-stopped
-  #   volumes:
-  #      - ${MAYAN_RABBITMQ_VOLUME:-rabbitmq}:/var/lib/rabbitmq
+#   # Enable to use RabbitMQ
+#   # rabbitmq:
+#   #   image: rabbitmq:${MAYAN_DOCKER_RABBITMQ_TAG:-3.8-alpine}
+#   #   environment:
+#   #     RABBITMQ_DEFAULT_USER: ${MAYAN_RABBITMQ_USER:-mayan}
+#   #     RABBITMQ_DEFAULT_PASS: ${MAYAN_RABBITMQ_PASSWORD:-mayanrabbitpass}
+#   #     RABBITMQ_DEFAULT_VHOST: ${MAYAN_RABBITMQ_VHOST:-mayan}
+#   #   networks:
+#   #     - bridge
+#   #   restart: unless-stopped
+#   #   volumes:
+#   #      - ${MAYAN_RABBITMQ_VOLUME:-rabbitmq}:/var/lib/rabbitmq
 
-volumes:
-  app:
-  postgres:
-  mountindex:
-  rabbitmq:
-  redis:
+# volumes:
+#   app:
+#   postgres:
+#   mountindex:
+#   rabbitmq:
+#   redis:

--- a/mayan/apps/appearance/templates/appearance/base_plain.html
+++ b/mayan/apps/appearance/templates/appearance/base_plain.html
@@ -19,9 +19,14 @@
             {% endblock base_title %}
         </title>
 
-        <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <link rel="preload" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/css/base.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/css/base.css'}"></noscript>
         {% block stylesheets %}{% endblock %}
 
         <style>

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -19,12 +19,24 @@
             {% endblock base_title %}
         </title>
 
-        <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/node_modules/toastr/build/toastr.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
-        <link href="{% static 'appearance/css/base.css' %}" media="screen" rel="stylesheet" type="text/css" />
+        <link rel="preload" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/select2/dist/css/select2.min.css'}"></noscript>
+
+        <link rel="preload" href="{% static 'appearance/node_modules/toastr/build/toastr.min.cs' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/node_modules/toastr/build/toastr.min.cs'}"></head>noscript>
+
+        <link rel="preload" href="{% static 'appearance/css/base.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+        <noscript><link rel="stylesheet" href="{% static 'appearance/css/base.css'}"></noscript>
+
         <style id="style-javascript"></style>
         {% appearance_app_templates template_name='head' %}
         {% block stylesheets %}{% endblock %}

--- a/mayan/apps/sources/templates/sources/app/head.html
+++ b/mayan/apps/sources/templates/sources/app/head.html
@@ -1,6 +1,7 @@
 {% load static %}
 
-<link href="{% static 'sources/node_modules/dropzone/dist/dropzone.css' %}" media="screen" rel="stylesheet" type="text/css" />
+<link rel="preload" href="{% static 'sources/node_modules/dropzone/dist/dropzone.css' %}" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<noscript><link rel="stylesheet" href="{% static 'sources/node_modules/dropzone/dist/dropzone.css'}"></noscript>
 
 <style>
     .dropzone .dz-preview .dz-details {


### PR DESCRIPTION
Resolves [Issue #50](https://github.com/CMU-313/Mayan-EDMS/issues/50). 

As described [here](https://web.dev/render-blocking-resources/?utm_source=lighthouse&utm_medium=devtools), render-blocking stylesheets can be loaded asynchronously using the `preload` link. For our purposes, non-critical CSS is defined as files with no or nearly no coverage. 

In this PR, I have tackled the following saving opportunities by requesting an asynchronous load and delaying the processing to onload as outlined in this [tutorial](https://web.dev/defer-non-critical-css/).
![image](https://user-images.githubusercontent.com/66378466/132247431-bdb8ceb7-3d95-4f90-90a7-f849cc7773e8.png)

At 1:07:35 PM on 9/6/2021, the Lighthouse metrics were as follows:
![image](https://user-images.githubusercontent.com/66378466/132247921-ef628f35-560e-46fc-b2eb-5750173474a9.png)
The score has jumped from **53** previously to **65** which is a 12 point jump. This is primarily because the first content paint time has been significantly reduced.

Lastly, the targeted issue has been handled because it no longer shows up as an opportunity to save under Performance.
![image](https://user-images.githubusercontent.com/66378466/132248013-9f17561c-8b69-48f7-ae75-fd3ede03c52e.png)

