### PR TITLE
Increase header background contrast ratio for new documents page

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -640,7 +640,7 @@ a i {
 }
 
 .dropdown-menu > li > a {
-    color: #585e5e;
+    color: #000000;
 }
 
 .dropdown-header {
@@ -648,4 +648,5 @@ a i {
     padding-top: 0px;
     padding-left: 0px;
     padding-right: 0px;
+    color: #000000;
 }


### PR DESCRIPTION
Resolves #51 

Increased lighthouse accessibility score from 79 to 88. 
<img width="831" alt="Screen Shot 2021-09-06 at 2 48 57 PM" src="https://user-images.githubusercontent.com/51449135/132253728-6a8cc52a-8bb2-43d1-bea2-b30a1aee6b1e.png">
