### PR TITLE
Changed the MissItem 's color to black to increase the contrast ratio.

### DIFF
--- a/mayan/apps/common/templates/common/app/viewport.html
+++ b/mayan/apps/common/templates/common/app/viewport.html
@@ -15,8 +15,8 @@
 {% if missing_items %}
     <div class="alert alert-warning">
         {% for item in missing_items %}
-            <p><strong>{{ item.label }}</strong> </p>
-            <p>
+            <p style="color:black;"><strong>{{ item.label }}</strong> </p>
+            <p style="color:black;">
                 {{ item.description }}
                 {% if item.view %}<a class="btn btn-primary btn-xs" href="{% url item.view %}">{% trans 'Click here to fix this.' %}</a>{% endif %}
             </p>


### PR DESCRIPTION
The contrast ratio for MissingItem in warning message templates is not good. Change the text to black to increase contrast ratio. This would apply to warnings messages like no document types or no document sources. Resolves #73 .
The score for accessibility is increased from 88 to 90
<img width="463" alt="Screen Shot 2021-09-07 at 11 21 28 AM" src="https://user-images.githubusercontent.com/44144879/132387074-7c88effc-2bf0-4dd0-b8db-496f93b99eb9.png">
