### PR TITLE
Removed Disabled Element from HTML Template

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -8,9 +8,6 @@
     <div class="panel-group" id="accordion-sidebar" role="tablist" aria-multiselectable="true">
         <div class="panel-heading" role="tab" id="menu-main-button-close">
             <h4 class="panel-title">
-                <a class="disabled" href="">
-                    <i class="fa fa-angle-double-left"></i>
-                </a>
             </h4>
         </div>
         {% navigation_resolve_menu name='main' as main_menus_results %}


### PR DESCRIPTION
Elements with the disabled class can't be activated (i.e. unclickable). Thus the element is just dead code (especially when not viewable the user and containing no useful href link).