### PR TITLE
changed hyperlink color

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -649,3 +649,7 @@ a i {
     padding-left: 0px;
     padding-right: 0px;
 }
+
+.new-window {
+    color: #006660;
+}

--- a/mayan/apps/appearance/templates/appearance/about.html
+++ b/mayan/apps/appearance/templates/appearance/about.html
@@ -85,7 +85,7 @@
         </p>
 
         <p class="text-center">
-            <i class="fa fa-home"></i><a href="{% common_project_information '__website__' %}"> {% common_project_information '__website__' %}</a>
+            <i class="fa fa-home"></i><a class="new-window" href="{% common_project_information '__website__' %}"> {% common_project_information '__website__' %}</a>
         </p>
 
         <p class="text-center">
@@ -109,25 +109,25 @@
 
         <p class="text-center">
             {% blocktrans with project_title as project_title and icon_social_paypal as icon_social_paypal%}
-                If you use {{ project_title }} please <a class="new_window" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3PXN336XFXQNN">make a donation {{ icon_social_paypal }}</a>
+                If you use {{ project_title }} please <a class="new-window" href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=3PXN336XFXQNN">make a donation {{ icon_social_paypal }}</a>
             {% endblocktrans %}
         </p>
 
         <p class="text-center">
             {% blocktrans with icon_documentation as icon_documentation and icon_wiki as icon_wiki %}
-                The complete list of changes is available via the <a class="new_window" href="https://docs.mayan-edms.com/releases/index.html">Release notes {{ icon_documentation }}</a> or the short version <a class="new_window" href="https://gitlab.com/mayan-edms/mayan-edms/blob/master/HISTORY.rst">Changelog {{ icon_documentation }}</a>.
+                The complete list of changes is available via the <a class="new-window" href="https://docs.mayan-edms.com/releases/index.html">Release notes {{ icon_documentation }}</a> or the short version <a class="new-window" href="https://gitlab.com/mayan-edms/mayan-edms/blob/master/HISTORY.rst">Changelog {{ icon_documentation }}</a>.
             {% endblocktrans %}
         </p>
 
         <p class="text-center">
             {% blocktrans with icon_documentation as icon_documentation %}
-                For questions check the <a class="new_window" href="https://docs.mayan-edms.com">Documentation {{ icon_documentation }}</a>.
+                For questions check the <a class="new-window" href="https://docs.mayan-edms.com">Documentation {{ icon_documentation }}</a>.
             {% endblocktrans %}
         </p>
 
         <p class="text-center">
             {% blocktrans with icon_forum as icon_forum and icon_source_code as icon_source_code %}
-                If you found a bug or have a feature idea, visit the <a class="new_window" href="https://forum.mayan-edms.com">Forum {{ icon_forum }}</a> or open a ticket in the <a class="new_window" href="https://gitlab.com/mayan-edms/mayan-edms">Source code repository {{ icon_source_code }}</a>.
+                If you found a bug or have a feature idea, visit the <a class="new-window" href="https://forum.mayan-edms.com">Forum {{ icon_forum }}</a> or open a ticket in the <a class="new-window" href="https://gitlab.com/mayan-edms/mayan-edms">Source code repository {{ icon_source_code }}</a>.
             {% endblocktrans %}
         </p>
         <p class="text-center">


### PR DESCRIPTION
Resolves #97

BEFORE:
- Light green hyperlinks were not good for accessibility of the "About" page

![image](https://user-images.githubusercontent.com/56563837/132576494-56128b84-9add-445d-90f6-80bf04f69db6.png)

AFTER:
- Changed hyperlink color to dark green
- Improved accessibility score of the "About" page by 2 points

![image](https://user-images.githubusercontent.com/56563837/132577021-d5e0c5f8-9a6a-41e1-ae74-4ad88c427035.png)
