### PR TITLE
Fixed duplicate ARIA id's issue

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -21,7 +21,7 @@
                     {% with ' ' as link_classes %}
                         {% if link|common_get_type == "<class 'mayan.apps.navigation.classes.Menu'>" %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingOneA">
                                     <h4 class="panel-title">
                                         <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
                                             <div class="pull-left">
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOneB">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}


### PR DESCRIPTION
resolves #103 
Changed ARIA id's for panel headings to be unique. Changes were made in the menu_main.html file. Lighthouse score for accessibility went up by 6 to 89 while all other scores remained constant.
