### PR TITLE
Improved Lighthouse SEO score from 78 to 89 by adding meta description. 

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ x-mayan-container:
     PYTHONDONTWRITEBYTECODE: 1
     MAYAN_CELERY_BROKER_URL: redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/0
     MAYAN_CELERY_RESULT_BACKEND: redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/1
-    MAYAN_DATABASES: "{'default':{'ENGINE':'django.db.backends.postgresql','NAME':'${MAYAN_DATABASE_NAME:-mayan}','PASSWORD':'${MAYAN_DATABASE_PASSWORD:-mayandbpass}','USER':'${MAYAN_DATABASE_USER:-mayan}','HOST':'${MAYAN_DATABASE_HOST:-postgresql}'}}"
+    MAYAN_DATABASES: "{'default':{'ENGINE':'django.db.backends.postgresql','NAME':'${MAYAN_DATABASE_NAME:-mayan}','PASSWORD':'${MAYAN_DATABASE_PASSWORD:-mayanuserpass}','USER':'${MAYAN_DATABASE_USER:-mayan}','HOST':'${MAYAN_DATABASE_HOST:-postgresql}'}}"
     MAYAN_DOCKER_WAIT: "${MAYAN_DATABASE_HOST:-postgresql}:5432 redis:6379"
     MAYAN_LOCK_MANAGER_BACKEND: mayan.apps.lock_manager.backends.redis_lock.RedisLock
     MAYAN_LOCK_MANAGER_BACKEND_ARGUMENTS: "{'redis_url':'redis://:${MAYAN_REDIS_PASSWORD:-mayanredispassword}@redis:6379/2'}"
@@ -60,7 +60,7 @@ services:
       - "work_mem=8MB"
     environment:
       POSTGRES_DB: ${MAYAN_DATABASE_NAME:-mayan}
-      POSTGRES_PASSWORD: ${MAYAN_DATABASE_PASSWORD:-mayandbpass}
+      POSTGRES_PASSWORD: ${MAYAN_DATABASE_PASSWORD:-mayanuserpass}
       POSTGRES_USER: ${MAYAN_DATABASE_USER:-mayan}
     image: postgres:${MAYAN_DOCKER_POSTGRES_TAG:-10.15-alpine}
     networks:
@@ -70,7 +70,7 @@ services:
     #  - "5432:5432"
     restart: unless-stopped
     volumes:
-      - ${PWD}/data/postgres:/var/lib/postgresql/data
+      - /docker-volumes/mayan-edms/postgres:/var/lib/postgresql/data:z
 
   redis:
     command:

--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -12,6 +12,8 @@
     <head>
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	    <meta name="description" content="The Mayan EDMS is a free, open-source Electronic Database Management System. It enables users to store different document versions, verify document authenticity, upload documents through many routes, support many file formats, and collaborate with others. The home menu enables users to access all parts of the system.">
+	    <meta name="keywords" content="Mayan, Mayan EDMS, Document System, vault, storage, drive,dashboard, repository">
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />
         <title>
             {% block base_title %}


### PR DESCRIPTION
The root.html file now has a meta description describing the Mayan EDMS page. Meta tags that include common search terms (ex: "Mayan", "Mayan EDMS", and synonyms for EDMS that may be commonly used) have also been added for user convenience.

This fixes #109 

The new Lighthouse Scores are:
![image](https://user-images.githubusercontent.com/72584468/132608850-77fce091-2ebf-49ca-929a-279bb3c9a83d.png)
