### PR TITLE
Feature/form checkbox label

### DIFF
--- a/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
@@ -85,8 +85,9 @@
                             {% for object in object_list %}
                                 <tr>
                                     {% if links_multi_menus_results %}
+
                                         <td>
-                                            <input class="form-multi-object-action-checkbox check-all-slave checkbox" name="pk_{{ object.pk }}" type="checkbox" value="" />
+                                            <input id="checkbox_{{object.pk}}" class="form-multi-object-action-checkbox check-all-slave checkbox" name="pk_{{ object.pk }}" type="checkbox" value="" />
                                         </td>
                                     {% endif %}
 
@@ -96,8 +97,13 @@
                                         {% navigation_get_source_columns source=object only_identifier=True as source_column %}
                                         {% if source_column %}
                                             {% navigation_source_column_resolve column=source_column as column_value %}
-                                            <td>
+                                            <td id="columnvalue">
                                                 {{ column_value }}
+                                                {% navigation_check_if_cache_label source_column=source_column as is_label %}
+                                                {% if is_label %}
+                                                    {% navigation_cache_list_column_value_text column_value=column_value as label_text%}
+                                                    <label for="checkbox_{{object.pk}}" hidden>{{ label_text }}</label>
+                                                {% endif %}
                                             </td>
                                         {% endif %}
                                     {% endif %}
@@ -115,7 +121,7 @@
                                     {% endif %}
 
                                     {% for column in extra_columns %}
-                                        <td>{{ object|common_object_property:column.attribute }}</td>
+                                        <td id="extraa">{{ object|common_object_property:column.attribute }}</td>
                                     {% endfor %}
 
                                     {% if not hide_links %}

--- a/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
@@ -101,8 +101,9 @@
                                                 {{ column_value }}
                                                 {% navigation_check_if_cache_label source_column=source_column as is_label %}
                                                 {% if is_label %}
-                                                    {% navigation_cache_list_column_value_text column_value=column_value as label_text%}
-                                                    <label for="checkbox_{{object.pk}}" hidden>{{ label_text }}</label>
+                                                    <label for="checkbox_{{object.pk}}">{{ column_value }}</label>
+                                                {% else %}
+                                                    {{ column_value }}
                                                 {% endif %}
                                             </td>
                                         {% endif %}

--- a/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
+++ b/mayan/apps/appearance/templates/appearance/generic_list_subtemplate.html
@@ -97,8 +97,7 @@
                                         {% navigation_get_source_columns source=object only_identifier=True as source_column %}
                                         {% if source_column %}
                                             {% navigation_source_column_resolve column=source_column as column_value %}
-                                            <td id="columnvalue">
-                                                {{ column_value }}
+                                            <td>
                                                 {% navigation_check_if_cache_label source_column=source_column as is_label %}
                                                 {% if is_label %}
                                                     <label for="checkbox_{{object.pk}}">{{ column_value }}</label>
@@ -122,7 +121,7 @@
                                     {% endif %}
 
                                     {% for column in extra_columns %}
-                                        <td id="extraa">{{ object|common_object_property:column.attribute }}</td>
+                                        <td>{{ object|common_object_property:column.attribute }}</td>
                                     {% endfor %}
 
                                     {% if not hide_links %}

--- a/mayan/apps/navigation/templatetags/navigation_tags.py
+++ b/mayan/apps/navigation/templatetags/navigation_tags.py
@@ -88,17 +88,6 @@ def navigation_source_column_resolve(context, column):
         return ''
 
 @register.simple_tag(takes_context=True)
-def navigation_cache_list_column_value_text(context, column_value):
-    # We exepct column value to be something like:
-    # <a href="some/path">text</a>
-    # and the "text" is what we want to extract to serve as a label for a checkbox
-    if column_value and column_value.find("<a") == 0:
-        ind = column_value.find(">")
-        return column_value[ind+1:-5] # Omit the last "</a>" part of the string
-    else:
-        return ''
-
-@register.simple_tag(takes_context=True)
 def navigation_check_if_cache_label(context, source_column):
     if source_column:
         return source_column.label == "Label"

--- a/mayan/apps/navigation/templatetags/navigation_tags.py
+++ b/mayan/apps/navigation/templatetags/navigation_tags.py
@@ -86,3 +86,21 @@ def navigation_source_column_resolve(context, column):
         return result
     else:
         return ''
+
+@register.simple_tag(takes_context=True)
+def navigation_cache_list_column_value_text(context, column_value):
+    # We exepct column value to be something like:
+    # <a href="some/path">text</a>
+    # and the "text" is what we want to extract to serve as a label for a checkbox
+    if column_value and column_value.find("<a") == 0:
+        ind = column_value.find(">")
+        return column_value[ind+1:-5] # Omit the last "</a>" part of the string
+    else:
+        return ''
+
+@register.simple_tag(takes_context=True)
+def navigation_check_if_cache_label(context, source_column):
+    if source_column:
+        return source_column.label == "Label"
+    else:
+        return False


### PR DESCRIPTION
## Issue
Resolves #101 
Refer to the original issue specification with the link above. 

## Solution idea
- Tables like this cache file page are generated through a generic template, so our solution also adhere to this dynamically generated method and change the template, instead of hardcoding labels. 
- Google lighthouse checks for _visible_ (ie not hidden) `label` elements that either encapsulates the form (our checkboxes), or directly references the form's id. In order to not disrupt the original appearance of the page, a fix must come from using an existing resource as labels (since you cannot add the `hidden` attribute to labels). In our cache file list, the 2nd column contains the label of the cache locations. 

## Implemented solution
The template is changed to condition on the column's name (it's name must be "Label"), and turns the original table entry `<a..>label text></a>` into a label: `<label for="checkbox_n"><a>...</a><label>`. Where `checkbox_n` is assigned based on the checkbox's order in the table. 

This is what a rendered table's elements look like (note that values like "Assets cache" are dynamically provided, and all I did was change the template in which data was fed into.
![code](https://user-images.githubusercontent.com/44855375/132610701-7a58f37d-e6db-4ae4-8e26-8bd9f655a79b.PNG)


## End result
The lighthouse score for the accessibility component has now risen from 82 to 89, with form labeling issue completely resolved.
![afterfixing](https://user-images.githubusercontent.com/44855375/132610053-7c03dccc-3293-4802-b343-47e998afbb49.PNG)
