### PR TITLE
Add Meta Description to 'Create New User' page to improve SEO

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -12,6 +12,7 @@
     <head>
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="description" content="The Mayan EDMS is a free, open-source document management system for managing documents within an organization.">
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />
         <title>
             {% block base_title %}


### PR DESCRIPTION
This pull request resolves #114 

Added a meta description to the 'Create new user' page to increase SEO score from 78 to 89. The meta description explained the function of Mayan EDMS by stating "The Mayan EDMS is a free, open-source document management system for managing documents within an organization." This change was made in the root.html file.

<img width="789" alt="Screen Shot 2021-09-08 at 10 59 35 PM" src="https://user-images.githubusercontent.com/32686125/132625472-299d5ce2-a6ab-4152-b0ee-da4a99672542.png">
