### PR TITLE
Changing the color of help-block to black to improve contrast (Accessibility)

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -649,3 +649,10 @@ a i {
     padding-left: 0px;
     padding-right: 0px;
 }
+
+.help-block {
+    display: block;
+    margin-top: 5px;
+    margin-bottom: 10px;
+    color: #000000 !important;
+}


### PR DESCRIPTION
This pull request resolves #112 

Changed the color of the `help-block` class to black to improve contrast on the 'Advanced Search' page. This was accomplished by adding a `help-block` css block to `base.css`. This change improved the accessibility score from 89 to 91 on the 'Advanced Search' page.

![Screen Shot 2021-09-09 at 1 02 17 AM](https://user-images.githubusercontent.com/11011325/132625740-0e1468e5-72b6-4504-8164-7a9d47194eef.png)
