### PR TITLE
Fix Lighthouse "Links do not have a discernible name" warning

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -9,6 +9,7 @@
         <div class="panel-heading" role="tab" id="menu-main-button-close">
             <h4 class="panel-title">
                 <a class="disabled" href="">
+                    Mayan EDMS
                     <i class="fa fa-angle-double-left"></i>
                 </a>
             </h4>


### PR DESCRIPTION
Resolve #122

Lighthouse "Accessibility" score goes from 89 to 91.

The only change I made is adding a "Mayan EDMS" text within the HTML a tag.