### PR TITLE
added descriptions for links to notifications and messages in navigation

### DIFF
--- a/mayan/apps/events/links.py
+++ b/mayan/apps/events/links.py
@@ -77,6 +77,6 @@ link_object_event_types_user_subcriptions_list = Link(
 )
 link_user_notifications_list = Link(
     badge_text=get_unread_notification_count,
-    icon=icon_user_notifications_list, text='',
+    icon=icon_user_notifications_list, text='Notifications',
     view='events:user_notifications_list'
 )

--- a/mayan/apps/messaging/links.py
+++ b/mayan/apps/messaging/links.py
@@ -47,7 +47,7 @@ link_message_single_delete = Link(
 )
 link_message_list = Link(
     badge_text=get_unread_message_count, icon=icon_message_list,
-    text='', view='messaging:message_list'
+    text="Inbox", view='messaging:message_list'
 )
 link_message_single_mark_read = Link(
     args='object.pk', conditional_disable=condition_is_read,


### PR DESCRIPTION
The lighthouse score for accessibility with no changes was 78.

The navigation bar had descriptions for System and User with their corresponding icons, but there was no description next to the icons representing the notification bell and messages. After adding these labels, the accessibility scores improved to 91 and the specific issue "Links do not have a discernible name" no longer appeared as an issue in the accessibility section on the home page. 