### PR TITLE
fixed duplicate IDs in menu_main.html

### DIFF
--- a/mayan/apps/appearance/templates/appearance/menu_main.html
+++ b/mayan/apps/appearance/templates/appearance/menu_main.html
@@ -21,7 +21,7 @@
                     {% with ' ' as link_classes %}
                         {% if link|common_get_type == "<class 'mayan.apps.navigation.classes.Menu'>" %}
                             <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
+                                <div class="panel-heading" role="tab" id="headingOne-{{link}}">
                                     <h4 class="panel-title">
                                         <a class="non-ajax collapsed" role="button" data-toggle="collapse" data-parent="#accordion-sidebar" href="#accordion-body-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapseOne">
                                             <div class="pull-left">
@@ -36,7 +36,7 @@
                                         </a>
                                     </h4>
                                 </div>
-                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div id="accordion-body-{{ forloop.counter }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne-{{link}}">
                                     <div class="panel-body">
                                         <ul class="list-unstyled">
                                             {% navigation_resolve_menu name=link.name as sub_menus_results %}


### PR DESCRIPTION
Resolves #126 

The menu_main.html template uses duplicate IDs on 2 elements. The change made them unique so that they could be picked up by assistive tools. 

The Lighthouse accessibility score was 85 and the improved score is 91. 