### PR TITLE
Changed colors of buttons, a link, and text to black to improve contrast

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -394,7 +394,7 @@ a i {
 }
 
 .btn-danger.btn-outline {
-    color: #d9534f;
+    color: #000000;
 }
 
 .btn-default.btn-outline:hover,
@@ -648,4 +648,15 @@ a i {
     padding-top: 0px;
     padding-left: 0px;
     padding-right: 0px;
+    color: black;
+}
+
+.btn-danger {
+    color: white;
+    background-color: black;
+    border-color: black;
+}
+
+a {
+    color: black;
 }


### PR DESCRIPTION
Resolved issue https://github.com/CMU-313/Mayan-EDMS/issues/113.

The colors of the Actions and Delete buttons, Label link, and the "Related" text were changed to black. This was done by overriding the previous .btn-danger class and link element (a) and changing the .dropdown-header class to contain the updated colors. The accessibility score improved by two points from 89 to 91. 
