### PR TITLE
Improvement of contrast on the Users page

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -423,14 +423,6 @@ a i {
   border-color: #000000 !important;
 }
 
-/* .btn.btn-danger.btn-xs {
-  background-color: #000000 !important;
-  border-color: #000000 !important;
-} */
-/* #content-title {
-  color: #5cb85c !important;
-} */
-
 .dropdown-header {
   color: #000000 !important;
 }

--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -418,6 +418,26 @@ a i {
     padding: 1px 5px 0px;
 }
 
+.btn-danger {
+  background-color: #901616 !important;
+  border-color: #000000 !important;
+}
+
+/* .btn.btn-danger.btn-xs {
+  background-color: #000000 !important;
+  border-color: #000000 !important;
+} */
+/* #content-title {
+  color: #5cb85c !important;
+} */
+
+.dropdown-header {
+  color: #000000 !important;
+}
+
+a {
+  color: #000000
+}
 /*
  * Top navigation
  * Hide default border to remove 1px line.


### PR DESCRIPTION
I changed the column headers from a greenish color to black to increase the contrast. I also changed the delete user and actions buttons to a darker red with a black border to increase contrast. I also changes a piece of text to a black color so it could be more visible. The Lighthouse score improved from 75 to 77.

<img width="631" alt="Screen Shot 2021-09-09 at 7 03 46 PM" src="https://user-images.githubusercontent.com/20130977/132775722-a4d8a6f0-3698-4903-9666-524c168b7b1d.png">
