### PR TITLE
Add labels to elements in form to improve accessibility

### DIFF
--- a/Leos.txt
+++ b/Leos.txt
@@ -1,0 +1,1 @@
+some random stuff to check if git is working

--- a/Leos.txt
+++ b/Leos.txt
@@ -1,1 +1,0 @@
-some random stuff to check if git is working

--- a/mayan/apps/appearance/templates/appearance/generic_form_instance.html
+++ b/mayan/apps/appearance/templates/appearance/generic_form_instance.html
@@ -33,6 +33,7 @@
                         {% endfor %}
                     </div>
                 {% else %}
+                    {{ field.label_tag }}
                     {% render_field field class+="form-control" %}
                 {% endif %}
             {% if field.errors %}</div>{% endif %}


### PR DESCRIPTION
Resolves #132 

After locating the django template for generic form instances, a generic label is created for each form element to increase accessibility.

We observe an improvement of lighthouse score from 84 to 89
<img width="941" alt="Screen Shot 2021-09-09 at 8 27 27 PM" src="https://user-images.githubusercontent.com/22224479/132779490-8dae6cd2-0e74-45ab-b2f6-3381126347be.png">


This implementation is similar to pull request #59. However, the solution in #59 uses a self-defined label whereas this implementation uses the default field.label_tag method. This implementation is more modularized and defers the work of creating labels when the table elements are generated.