### PR TITLE
Change Google Fonts loading behavior to improve rendering performance

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -18,7 +18,9 @@
                 {% block title %}{% endblock %} :: {% block project_name %}{% smart_setting 'COMMON_PROJECT_TITLE' %}{% endblock %}
             {% endblock base_title %}
         </title>
-
+        <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous">
+        <link href="https://fonts.googleapis.com/css2?family=Lato&display=swap" rel="stylesheet"> 
         <link href="{% static 'appearance/node_modules/@fortawesome/fontawesome-free/css/all.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/bootswatch/flatly/bootstrap.min.css' %}" media="screen" rel="stylesheet" type="text/css" />
         <link href="{% static 'appearance/node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css' %}" media="screen" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Resolves #138.
This change prioritizes retrieving the Lato font from Google Fonts, improving the performance of content loading and reducing the risk of a "flash of invisible text". 
The most dramatic impact was seen in Lighthouse testing on the login page, where performance improved 12 points between tests:

![image](https://user-images.githubusercontent.com/81904149/132780850-ffd71616-d525-4111-8ef9-9b121e89a34d.png)
_Before_

![image](https://user-images.githubusercontent.com/81904149/132780905-767622ba-11b5-4374-84c3-aad6c79220d9.png)
_After_

In addition, "potential savings" on webfont load times decreased substantially:

![image](https://user-images.githubusercontent.com/81904149/132781102-ef2455ce-2655-47f4-856e-94b4b3bb4051.png)
_Before_

![image](https://user-images.githubusercontent.com/81904149/132781068-b311c043-405e-484b-b32e-edae2eae72a8.png)
_After_

