### PR TITLE
Changed color of Cancel button and input box description text for contrast

### DIFF
--- a/mayan/apps/appearance/static/appearance/css/base.css
+++ b/mayan/apps/appearance/static/appearance/css/base.css
@@ -397,7 +397,17 @@ a i {
     color: #d9534f;
 }
 
-.btn-default.btn-outline:hover,
+.btn-default {
+    color: #000000 !important;
+}
+
+.help-block {
+    color: #000000 !important;
+}
+
+.btn-default.btn-outline:hover {
+    color: #000000 !important;
+}
 .btn-primary.btn-outline:hover,
 .btn-success.btn-outline:hover,
 .btn-info.btn-outline:hover,


### PR DESCRIPTION
Resolves #137.

Modified `base.css` to update the color of the Cancel button and input box description text to black. This increases the contrast between elements, and **improves lighthouse Accessibility score from 83 to 86**.