### PR TITLE
RESOLVED SEO: meta data issue

### DIFF
--- a/mayan/apps/appearance/templates/appearance/root.html
+++ b/mayan/apps/appearance/templates/appearance/root.html
@@ -13,6 +13,7 @@
         <meta content="width=device-width, initial-scale=1, maximum-scale=5" name="viewport">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="Content-Language" content="{{ LANGUAGE_CODE }}" />
+        <meta name="description" content="Your documents. No surprises. Find what you need with advanced search, tagging and categorization capabilities. Automate you business processes with workflows."
         <title>
             {% block base_title %}
                 {% block title %}{% endblock %} :: {% block project_name %}{% smart_setting 'COMMON_PROJECT_TITLE' %}{% endblock %}


### PR DESCRIPTION
The SEO score across the website is increased from 78 to 89. 

Issue description
The website does not have a meta data description for search engines to display the description of the website for the results. 

Solution Implented
In the root.html file, where all the meta tags are contained, I inserted an extra line containing the meta data category and wrote a simple description of the website. The description was about 155 characters: "Your documents. No surprises. Find what you need with advanced search, tagging and categorization capabilities. Automate you business processes with workflows."

Resolved #58